### PR TITLE
Removed PF_RING reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Right now, I'd recommend using logstash to ship the logs to an elasticsearch clu
 
 ##Build and install
    * clone this repo
-   * install libpcap, libpcap-dev and PF_RING
+   * install libpcap, libpcap-dev
    * 'go get'
    * 'go build -o gopassivedns'  (the -o is really just being careful, assuming you cloned the repo you shouldn't need it)
    * 'cp gopassivedns /some/path/to/gopassivedns'


### PR DESCRIPTION
pfring code has been commented out in https://github.com/Phillipmartin/gopassivedns/commit/442b4cb975bf5e1086545a5b45ef57fbc227c8af
Removing from compilation instructions since it will not be used (yet?)