### PR TITLE
Cleanly exit, improve profiling and gofmt

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,57 +7,57 @@ import log "github.com/Sirupsen/logrus"
 
 // codebeat:disable[TOO_MANY_IVARS]
 type pdnsConfig struct {
-	device string
+	device   string
 	pcapFile string
-	bpf string
-	
+	bpf      string
+
 	sensorName string
-	debug bool
+	debug      bool
 	cpuprofile string
-	quiet bool
-	gcAge string
+	quiet      bool
+	gcAge      string
 	gcInterval string
-	numprocs int
-	pfring bool
-	
-	kafkaBrokers string
-	kafkaTopic string
-	logFile string
-	logMaxAge int
-	logMaxSize int
-	logMaxBackups int
-	statsdHost string
+	numprocs   int
+	pfring     bool
+
+	kafkaBrokers   string
+	kafkaTopic     string
+	logFile        string
+	logMaxAge      int
+	logMaxSize     int
+	logMaxBackups  int
+	statsdHost     string
 	statsdInterval int
-	statsdPrefix string
+	statsdPrefix   string
 	syslogFacility string
 	syslogPriority string
 }
 
 func initConfig() *pdnsConfig {
-    config := pdnsConfig{}
+	config := pdnsConfig{}
 
 	var dev = flag.String("dev", getEnvStr("PDNS_DEV", ""), "Capture Device")
 	var kafkaBrokers = flag.String("kafka_brokers", getEnvStr("PDNS_KAFKA_PEERS", ""), "The Kafka brokers to connect to, as a comma separated list")
 	var kafkaTopic = flag.String("kafka_topic", getEnvStr("PDNS_KAFKA_TOPIC", ""), "Kafka topic for output")
-	var bpf = flag.String("bpf", getEnvStr("PDNS_BPF", "port 53"), "BPF Filter")  //default port 53
+	var bpf = flag.String("bpf", getEnvStr("PDNS_BPF", "port 53"), "BPF Filter") //default port 53
 	var pcapFile = flag.String("pcap", getEnvStr("PDNS_PCAP_FILE", ""), "pcap file")
 	var logFile = flag.String("logfile", getEnvStr("PDNS_LOG_FILE", ""), "log file (recommended for debug only")
-	var logMaxAge = flag.Int("logMaxAge", getEnvInt("PDNS_LOG_AGE", 28), "max age of a log file before rotation, in days")  //8
-	var logMaxBackups = flag.Int("logMaxBackups", getEnvInt("PDNS_LOG_BACKUP", 3), "max number of files kept after rotation")  //8
-	var logMaxSize = flag.Int("logMaxSize", getEnvInt("PDNS_LOG_SIZE", 100), "max size of log file before rotation, in MB")  //8
+	var logMaxAge = flag.Int("logMaxAge", getEnvInt("PDNS_LOG_AGE", 28), "max age of a log file before rotation, in days")    //8
+	var logMaxBackups = flag.Int("logMaxBackups", getEnvInt("PDNS_LOG_BACKUP", 3), "max number of files kept after rotation") //8
+	var logMaxSize = flag.Int("logMaxSize", getEnvInt("PDNS_LOG_SIZE", 100), "max size of log file before rotation, in MB")   //8
 	var quiet = flag.Bool("quiet", getEnvBool("PDNS_QUIET", false), "do not log to stdout")
-	var gcAge = flag.String("gc_age", getEnvStr("PDNS_GC_AGE", "-1m"), "How old a connection table entry should be before it is garbage collected.")  //-1m
-	var gcInterval = flag.String("gc_interval", getEnvStr("PDNS_GC_INTERVAL", "3m"), "How often to run garbage collection.")  //3m
-	var debug = flag.Bool("debug", getEnvBool("PDNS_DEBUG", false), "Enable debug logging") 
+	var gcAge = flag.String("gc_age", getEnvStr("PDNS_GC_AGE", "-1m"), "How old a connection table entry should be before it is garbage collected.") //-1m
+	var gcInterval = flag.String("gc_interval", getEnvStr("PDNS_GC_INTERVAL", "3m"), "How often to run garbage collection.")                         //3m
+	var debug = flag.Bool("debug", getEnvBool("PDNS_DEBUG", false), "Enable debug logging")
 	var cpuprofile = flag.String("cpuprofile", getEnvStr("PDNS_PROFILE_FILE", ""), "write cpu profile to file") //""
-	var numprocs = flag.Int("numprocs", getEnvInt("PDNS_THREADS", 8), "number of packet processing threads")  //8
+	var numprocs = flag.Int("numprocs", getEnvInt("PDNS_THREADS", 8), "number of packet processing threads")    //8
 	var pfring = flag.Bool("pfring", getEnvBool("PDNS_PFRING", false), "Capture using PF_RING")
 	var sensorName = flag.String("name", getEnvStr("PDNS_NAME", ""), "sensor name used in logging and stats reporting")
 	var statsdHost = flag.String("statsd_host", getEnvStr("PDNS_STATSD_HOST", ""), "Statsd server hostname or IP")
-	var statsdInterval = flag.Int("statsd_interval", getEnvInt("PDNS_STATSD_INTERVAL", 3), "Seconds between metric flush") //3
-	var statsdPrefix = flag.String("statsd_prefix", getEnvStr("PDNS_STATSD_PREFIX", "gopassivedns"), "statsd metric prefix")  //gopassivedns
-	var syslogFacility = flag.String("syslog_facility", getEnvStr("PDNS_SYSLOG_FACILITY", ""), "syslog facility")  //gopassivedns
-	var syslogPriority = flag.String("syslog_priority", getEnvStr("PDNS_SYSLOG_PRIORITY", "info"), "syslog priority")  //gopassivedns
+	var statsdInterval = flag.Int("statsd_interval", getEnvInt("PDNS_STATSD_INTERVAL", 3), "Seconds between metric flush")   //3
+	var statsdPrefix = flag.String("statsd_prefix", getEnvStr("PDNS_STATSD_PREFIX", "gopassivedns"), "statsd metric prefix") //gopassivedns
+	var syslogFacility = flag.String("syslog_facility", getEnvStr("PDNS_SYSLOG_FACILITY", ""), "syslog facility")            //gopassivedns
+	var syslogPriority = flag.String("syslog_priority", getEnvStr("PDNS_SYSLOG_PRIORITY", "info"), "syslog priority")        //gopassivedns
 	var configFile = flag.String("config", getEnvStr("PDNS_CONFIG", ""), "config file")
 
 	flag.Parse()
@@ -76,36 +76,36 @@ func initConfig() *pdnsConfig {
 	//if we get a config file, ignore everything else and load it
 	if *configFile != "" {
 		//load file
-	}else{
+	} else {
 		//pack the vars into the config struct
 		config = pdnsConfig{
-			device:			*dev,
-			pcapFile:		*pcapFile,
-			bpf:			*bpf,
-			
-			sensorName:		*sensorName,
-			debug:			*debug,
-			cpuprofile:		*cpuprofile,
-			quiet:			*quiet,
-			gcAge:			*gcAge,
-			gcInterval:		*gcInterval,
-			numprocs:		*numprocs,
-			pfring:			*pfring,
-			
-			kafkaBrokers:	*kafkaBrokers,
-			kafkaTopic:		*kafkaTopic,
-			logFile:		*logFile,
+			device:   *dev,
+			pcapFile: *pcapFile,
+			bpf:      *bpf,
+
+			sensorName: *sensorName,
+			debug:      *debug,
+			cpuprofile: *cpuprofile,
+			quiet:      *quiet,
+			gcAge:      *gcAge,
+			gcInterval: *gcInterval,
+			numprocs:   *numprocs,
+			pfring:     *pfring,
+
+			kafkaBrokers:   *kafkaBrokers,
+			kafkaTopic:     *kafkaTopic,
+			logFile:        *logFile,
 			logMaxAge:      *logMaxAge,
-	        logMaxSize:     *logMaxSize,
-	        logMaxBackups:  *logMaxBackups,
-			statsdHost:		*statsdHost,
-			statsdInterval:	*statsdInterval,
-			statsdPrefix:	*statsdPrefix,
+			logMaxSize:     *logMaxSize,
+			logMaxBackups:  *logMaxBackups,
+			statsdHost:     *statsdHost,
+			statsdInterval: *statsdInterval,
+			statsdPrefix:   *statsdPrefix,
 			syslogFacility: *syslogFacility,
 			syslogPriority: *syslogPriority,
 		}
 	}
-	
+
 	return &config
 }
 
@@ -113,7 +113,7 @@ func getEnvStr(name string, def string) string {
 	content, found := os.LookupEnv(name)
 	if found {
 		return content
-	}else{
+	} else {
 		return def
 	}
 }
@@ -124,11 +124,11 @@ func getEnvBool(name string, def bool) bool {
 		parsed, err := strconv.ParseBool(content)
 		if err == nil {
 			return parsed
-		}else{
+		} else {
 			log.Debugf("Could not parse the content of %s, %s, as a bool", name, content)
 			return def
 		}
-	}else{
+	} else {
 		return def
 	}
 }
@@ -136,14 +136,14 @@ func getEnvBool(name string, def bool) bool {
 func getEnvInt(name string, def int) int {
 	content, found := os.LookupEnv(name)
 	if found {
-		parsed,err := strconv.ParseInt(content, 0, 32)
+		parsed, err := strconv.ParseInt(content, 0, 32)
 		if err == nil {
 			return int(parsed)
-		}else{
+		} else {
 			log.Debugf("Could not parse the content of %s, %s, as an int", name, content)
 			return def
 		}
-	}else{
+	} else {
 		return def
 	}
 }

--- a/log.go
+++ b/log.go
@@ -14,30 +14,30 @@ import "log/syslog"
 
 // codebeat:disable[TOO_MANY_IVARS]
 type logOptions struct {
-	quiet        bool
-	debug        bool
-	Filename     string
-	MaxAge		 int
-	MaxBackups	 int
-	MaxSize		 int
-	KafkaBrokers string
-	KafkaTopic   string
+	quiet          bool
+	debug          bool
+	Filename       string
+	MaxAge         int
+	MaxBackups     int
+	MaxSize        int
+	KafkaBrokers   string
+	KafkaTopic     string
 	SyslogFacility string
 	SyslogPriority string
-	closed       bool
-	control      chan string
+	closed         bool
+	control        chan string
 }
 
 func NewLogOptions(config *pdnsConfig) *logOptions {
 	return &logOptions{
-		quiet:        config.quiet,
-		debug:        config.debug,
-		Filename:     config.logFile,
-		KafkaBrokers: config.kafkaBrokers,
-		KafkaTopic:   config.kafkaTopic,
-		MaxAge:		  config.logMaxAge,
-		MaxSize:	  config.logMaxSize,
-		MaxBackups:	  config.logMaxBackups,
+		quiet:          config.quiet,
+		debug:          config.debug,
+		Filename:       config.logFile,
+		KafkaBrokers:   config.kafkaBrokers,
+		KafkaTopic:     config.kafkaTopic,
+		MaxAge:         config.logMaxAge,
+		MaxSize:        config.logMaxSize,
+		MaxBackups:     config.logMaxBackups,
 		SyslogFacility: config.syslogFacility,
 		SyslogPriority: config.syslogPriority,
 	}
@@ -79,6 +79,7 @@ type dnsLogEntry struct {
 	encoded []byte //to hold the marshaled data structure
 	err     error  //encoding errors
 }
+
 // codebeat:enable[TOO_MANY_IVARS]
 
 //private, idempotent function that ensures the json is encoded
@@ -151,8 +152,8 @@ func logConn(logC chan dnsLogEntry, opts *logOptions, stats *statsd.StatsdBuffer
 		logs = append(logs, kafkaChan)
 		go logConnKafka(kafkaChan, opts)
 	}
-	
-	if opts.LogToSyslog(){
+
+	if opts.LogToSyslog() {
 		log.Debug("syslog logging enabled")
 		syslogChan := make(chan dnsLogEntry)
 		logs = append(logs, syslogChan)
@@ -217,7 +218,7 @@ func logConnKafka(logC chan dnsLogEntry, opts *logOptions) {
 
 //logs to syslog
 func logConnSyslog(logC chan dnsLogEntry, opts *logOptions) {
-	
+
 	level, err := levelToType(opts.SyslogPriority)
 	if err != nil {
 		log.Fatalf("string '%s' did not parse as a priority", opts.SyslogPriority)
@@ -226,12 +227,12 @@ func logConnSyslog(logC chan dnsLogEntry, opts *logOptions) {
 	if err != nil {
 		log.Fatalf("string '%s' did not parse as a facility", opts.SyslogFacility)
 	}
-	
+
 	logger, err := syslog.New(facility|level, "")
 	if err != nil {
 		log.Fatalf("failed to connect to the local syslog daemon: %s", err)
 	}
-	
+
 	for message := range logC {
 		encoded, _ := message.Encode()
 		logger.Write([]byte(encoded))
@@ -289,23 +290,23 @@ func facilityToType(facility string) (syslog.Priority, error) {
 func levelToType(level string) (syslog.Priority, error) {
 	level = strings.ToUpper(level)
 	switch level {
-		case "EMERG":
-			return syslog.LOG_EMERG, nil
-		case "ALERT":
-			return syslog.LOG_ALERT, nil
-		case "CRIT":
-			return syslog.LOG_CRIT, nil
-		case "ERR":
-			return syslog.LOG_ERR, nil
-		case "WARNING":
-			return syslog.LOG_WARNING, nil
-		case "NOTICE":
-			return syslog.LOG_NOTICE, nil
-		case "INFO":
-			return syslog.LOG_INFO, nil
-		case "DEBUG":
-			return syslog.LOG_DEBUG, nil
-		default:
-			return 0, fmt.Errorf("Unknown priority: %s", level)
-		}
+	case "EMERG":
+		return syslog.LOG_EMERG, nil
+	case "ALERT":
+		return syslog.LOG_ALERT, nil
+	case "CRIT":
+		return syslog.LOG_CRIT, nil
+	case "ERR":
+		return syslog.LOG_ERR, nil
+	case "WARNING":
+		return syslog.LOG_WARNING, nil
+	case "NOTICE":
+		return syslog.LOG_NOTICE, nil
+	case "INFO":
+		return syslog.LOG_INFO, nil
+	case "DEBUG":
+		return syslog.LOG_DEBUG, nil
+	default:
+		return 0, fmt.Errorf("Unknown priority: %s", level)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -229,71 +229,71 @@ func TestDefaultConfig(t *testing.T) {
 	//os.Setenv("PDNS_CONFIG", "")
 
 	config := initConfig()
-	
+
 	if config.device != "aaa" {
 		t.Fatal("")
 	}
-	
+
 	if config.kafkaBrokers != "bbb" {
 		t.Fatal("")
 	}
-	
+
 	if config.kafkaTopic != "ccc" {
 		t.Fatal("")
 	}
-	
+
 	if config.bpf != "ddd" {
 		t.Fatal("")
 	}
-	
+
 	if config.pcapFile != "eee" {
 		t.Fatal("")
 	}
-	
+
 	if config.logFile != "fff" {
 		t.Fatal("")
 	}
-	
+
 	if config.logMaxAge != 111 {
 		t.Fatal("")
 	}
-	
+
 	if config.logMaxBackups != 3 {
 		t.Fatal("")
 	}
-	
+
 	if config.logMaxSize != 100 {
 		t.Fatal("")
 	}
-	
+
 	if config.quiet != false {
 		t.Fatal("")
 	}
-	
+
 	if config.gcAge != "-1m" {
 		t.Fatal("")
 	}
-	
+
 	if config.gcInterval != "3m" {
 		t.Fatal("")
 	}
-	
+
 	if config.debug != false {
 		t.Fatal("")
 	}
-	
+
 	if config.cpuprofile != "ggg" {
 		t.Fatal("")
 	}
-	
+
 	if config.numprocs != 8 {
 		t.Fatal("")
 	}
-	
+
 	if config.pfring != true {
 		t.Fatal("")
 	}
-	
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		if config.sensorName != "UNKNOWN" {
@@ -308,15 +308,15 @@ func TestDefaultConfig(t *testing.T) {
 	if config.statsdHost != "iii" {
 		t.Fatal("")
 	}
-	
+
 	if config.statsdInterval != 777 {
 		t.Fatal("")
 	}
-	
+
 	if config.statsdPrefix != "jjj" {
 		t.Fatal("")
 	}
-	
+
 	os.Unsetenv("PDNS_DEV")
 	os.Unsetenv("PDNS_KAFKA_PEERS")
 	os.Unsetenv("PDNS_KAFKA_TOPIC")
@@ -337,7 +337,7 @@ func TestDefaultConfig(t *testing.T) {
 	os.Unsetenv("PDNS_STATSD_HOST")
 	os.Unsetenv("PDNS_STATSD_INTERVAL")
 	os.Unsetenv("PDNS_STATSD_PREFIX")
-	
+
 }
 
 func TestParseA(t *testing.T) {
@@ -759,10 +759,11 @@ func TestDoCaptureUDP(t *testing.T) {
 	var logChan = make(chan dnsLogEntry, 100)
 	var reChan = make(chan tcpDataStruct)
 	var logStash = make(chan dnsLogEntry, 100)
+	var done = make(chan bool, 1)
 
 	go LogMirrorBg(logChan, logStash)
 
-	doCapture(handle, logChan, &pdnsConfig{gcAge:"-1m", gcInterval:"3m", numprocs: 8}, reChan, stats)
+	doCapture(handle, logChan, &pdnsConfig{gcAge: "-1m", gcInterval: "3m", numprocs: 8}, reChan, stats, done)
 
 	logs := ToSlice(logStash)
 
@@ -778,10 +779,11 @@ func TestDoCaptureTCP(t *testing.T) {
 	var logChan = make(chan dnsLogEntry, 400)
 	var reChan = make(chan tcpDataStruct, 1000)
 	var logStash = make(chan dnsLogEntry, 400)
+	var done = make(chan bool, 1)
 
 	go LogMirrorBg(logChan, logStash)
 
-	doCapture(handle, logChan, &pdnsConfig{gcAge:"-1m", gcInterval:"3m", numprocs: 8}, reChan, stats)
+	doCapture(handle, logChan, &pdnsConfig{gcAge: "-1m", gcInterval: "3m", numprocs: 8}, reChan, stats, done)
 
 	logs := ToSlice(logStash)
 
@@ -927,14 +929,13 @@ func TestInitHandleDev(t *testing.T) {
 	}
 }
 
-
 func TestParseLevel(t *testing.T) {
 
 }
 
 func TestParseFacility(t *testing.T) {
 	m := make(map[string]syslog.Priority)
-	
+
 	m["KERN"] = syslog.LOG_KERN
 	m["USER"] = syslog.LOG_USER
 	m["MAIL"] = syslog.LOG_MAIL
@@ -955,45 +956,45 @@ func TestParseFacility(t *testing.T) {
 	m["LOCAL5"] = syslog.LOG_LOCAL5
 	m["LOCAL6"] = syslog.LOG_LOCAL6
 	m["LOCAL7"] = syslog.LOG_LOCAL7
-	
+
 	for k, v := range m {
 		fac, err := facilityToType(k)
 		if fac != v || err != nil {
 			t.Fatalf("facility %s did not parse as a facility", k)
 		}
 	}
-	
+
 	fac, err := facilityToType("notafac")
 	if fac != 0 || err == nil {
 		t.Fatal("facility 'notafac' return an error")
 	}
-	
+
 }
 
 func TestParsePriority(t *testing.T) {
 	m := make(map[string]syslog.Priority)
-	
-		m["EMERG"] = syslog.LOG_EMERG
-		m["ALERT"] = syslog.LOG_ALERT
-		m["CRIT"] = syslog.LOG_CRIT
-		m["ERR"] = syslog.LOG_ERR
-		m["WARNING"] = syslog.LOG_WARNING
-		m["NOTICE"] = syslog.LOG_NOTICE
-		m["INFO"] = syslog.LOG_INFO
-		m["DEBUG"] = syslog.LOG_DEBUG
-	
+
+	m["EMERG"] = syslog.LOG_EMERG
+	m["ALERT"] = syslog.LOG_ALERT
+	m["CRIT"] = syslog.LOG_CRIT
+	m["ERR"] = syslog.LOG_ERR
+	m["WARNING"] = syslog.LOG_WARNING
+	m["NOTICE"] = syslog.LOG_NOTICE
+	m["INFO"] = syslog.LOG_INFO
+	m["DEBUG"] = syslog.LOG_DEBUG
+
 	for k, v := range m {
 		fac, err := levelToType(k)
 		if fac != v || err != nil {
 			t.Fatalf("facility %s did not parse as a facility", k)
 		}
 	}
-	
+
 	fac, err := levelToType("notapri")
 	if fac != 0 || err == nil {
 		t.Fatal("facility 'notafac' return an error")
 	}
-	
+
 }
 
 /*
@@ -1002,17 +1003,17 @@ func TestInitLogging(t *testing.T){
 }
 */
 
-func TestMain(m *testing.M){
+func TestMain(m *testing.M) {
 	var statsdHost = flag.String("test_statsd_host", "", "Statsd server hostname or IP")
 	var statsdInterval = flag.Int("test_statsd_interval", 3, "Seconds between metric flush")
 	var statsdPrefix = flag.String("test_statsd_prefix", "gopassivedns", "statsd metric prefix")
-	
+
 	flag.Parse()
-	
+
 	if *statsdHost != "" {
 		statsdclient := statsd.NewStatsdClient(*statsdHost, *statsdPrefix)
 		stats = statsd.NewStatsdBuffer(time.Duration(*statsdInterval)*time.Second, statsdclient)
 	}
-	
+
 	os.Exit(m.Run())
 }

--- a/packets.go
+++ b/packets.go
@@ -26,6 +26,7 @@ type packetData struct {
 	dns      *layers.DNS
 	payload  *gopacket.Payload
 }
+
 // codebeat:enable[TOO_MANY_IVARS]
 
 func NewTcpData(tcpdata tcpDataStruct) *packetData {


### PR DESCRIPTION
Hi, 

Thanks for all your hard work on this tool. It has been super useful to us, and we would like to contribute back some of the production changes we have made to the tool.

* fix profiling
** profiling was not outputting a file because os.Exit means the defer statements would not execute.  because the profiler Stop() was a defer statement the profile was never written to disk.

* Using this tool on very busy servers (5k qps+) we noticed that it was not cleanly exiting from within systemd. To resolve that we have a handler to manage the signals and cleanly exit doCapture. To cleanly exit we send a bool down the done channel, that makes the select statement break the CAPTURE and run gracefulshutdown. This also complements the profiling, as we now have a clean exit of the entire tool we get more accurate profiling.

* go fmt
** formatting the code so that it's nicer to read and more go-ish.