### PR TITLE
format imports to be more go idomatic, increase channel sizes for sta…

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,9 +1,11 @@
 package main
 
-import "os"
-import "strconv"
-import "flag"
-import log "github.com/Sirupsen/logrus"
+import (
+	"flag"
+	log "github.com/Sirupsen/logrus"
+	"os"
+	"strconv"
+)
 
 // codebeat:disable[TOO_MANY_IVARS]
 type pdnsConfig struct {

--- a/log.go
+++ b/log.go
@@ -1,16 +1,18 @@
 package main
 
-import "bufio"
-import "net"
-import "fmt"
-import "time"
-import "strconv"
-import "strings"
-import "gopkg.in/natefinch/lumberjack.v2"
-import "github.com/pquerna/ffjson/ffjson"
-import log "github.com/Sirupsen/logrus"
-import "github.com/quipo/statsd"
-import "log/syslog"
+import (
+	"bufio"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/pquerna/ffjson/ffjson"
+	"github.com/quipo/statsd"
+	"gopkg.in/natefinch/lumberjack.v2"
+	"log/syslog"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
 
 // codebeat:disable[TOO_MANY_IVARS]
 type logOptions struct {
@@ -109,7 +111,7 @@ func initLogging(opts *logOptions) chan dnsLogEntry {
 	//TODO: further logging setup?
 
 	/* spin up logging channel */
-	var logChan = make(chan dnsLogEntry, 100)
+	var logChan = make(chan dnsLogEntry, 1000)
 
 	return logChan
 

--- a/main.go
+++ b/main.go
@@ -1,24 +1,24 @@
 package main
 
-import log "github.com/Sirupsen/logrus"
-import "strconv"
-import "time"
-import "net"
-import "os"
-import "os/signal"
-import "io"
-import "runtime/pprof"
-import "encoding/binary"
-import "syscall"
-
-import "github.com/google/gopacket"
-import "github.com/google/gopacket/pcap"
-import "github.com/google/gopacket/tcpassembly"
-import "github.com/google/gopacket/tcpassembly/tcpreader"
-
-import "github.com/google/gopacket/layers"
-import "github.com/quipo/statsd"
-import _ "github.com/joho/godotenv/autoload"
+import (
+	"encoding/binary"
+	log "github.com/Sirupsen/logrus"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"github.com/google/gopacket/tcpassembly"
+	"github.com/google/gopacket/tcpassembly/tcpreader"
+	_ "github.com/joho/godotenv/autoload"
+	"github.com/quipo/statsd"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"strconv"
+	"syscall"
+	"time"
+)
 
 /*
 
@@ -376,7 +376,7 @@ func doCapture(handle *pcap.Handle, logChan chan dnsLogEntry,
 	/* init channels for the packet handlers and kick off handler threads */
 	var channels []chan *packetData
 	for i := 0; i < config.numprocs; i++ {
-		channels = append(channels, make(chan *packetData, 100))
+		channels = append(channels, make(chan *packetData, 500))
 	}
 
 	for i := 0; i < config.numprocs; i++ {

--- a/main_test.go
+++ b/main_test.go
@@ -1,16 +1,18 @@
 package main
 
-import "testing"
-import "github.com/google/gopacket"
-import "github.com/google/gopacket/pcap"
-import "github.com/google/gopacket/layers"
-import "github.com/quipo/statsd"
-import "os/user"
-import "log/syslog"
-import "os"
-import "time"
-import "net"
-import "flag"
+import (
+	"flag"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"github.com/quipo/statsd"
+	"log/syslog"
+	"net"
+	"os"
+	"os/user"
+	"testing"
+	"time"
+)
 
 var stats *statsd.StatsdBuffer = nil
 

--- a/packets.go
+++ b/packets.go
@@ -1,10 +1,12 @@
 package main
 
-import "time"
-import "errors"
-import "net"
-import "github.com/google/gopacket"
-import "github.com/google/gopacket/layers"
+import (
+	"errors"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"net"
+	"time"
+)
 
 /*
   struct to store either reassembled TCP streams or packets

--- a/util.go
+++ b/util.go
@@ -1,8 +1,10 @@
 package main
 
-import "strconv"
-import "github.com/google/gopacket/layers"
-import "github.com/google/gopacket"
+import (
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"strconv"
+)
 
 /*
    The gopacket DNS layer doesn't have a lot of good String()


### PR DESCRIPTION
This is mostly a style PR. Changing the single line imports to a single import statement. Mostly personal preference.

I've also increased the channel buffer sizes to 500 per cpu and 1000 for the logging channel. In our production environment this has improved stability dramatically.