### PR TITLE
fix panic, add fluentd logging, output more data in logging fields for forensic use cases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Resolver support for query logging, including both the question and answer is sp
 Configuration options can be specified as environment variables, in a .env file on on the command line.  The priority is command line flags, .env file, and finally variables already defined in the environment.  Configuration options are as below
 
    * -dev [device]              network device for capture (ENV: PDNS_DEV)
+   * -fluentd_socket [socket]   Path to Fluentd unix socket used for logging in messagepack format (ENV: PDNS_FLUENTD_SOCKET)
    * -bpf [bpf filter]          BPF filter for capture (default: port 53) (ENV: PDNS_BPF)
    * -pcap [file]               pcap file to process (ENV: PDNS_PCAP_FILE)
    * -logfile [file]            log file for DNS lookups (suggested for small deployment or debugging only) (ENV: PDNS_LOG_FILE)
@@ -40,6 +41,7 @@ Configuration options can be specified as environment variables, in a .env file 
    * -statsd_host               host and port of your statsd server (e.g. localhost:8125) (ENV: PDNS_STATSD_HOST)
    * -statsd_interval           the interval, in seconds, between sends to statsd (ENV: PDNS_STATSD_INTERVAL)
    * -statsd_prefix             the metric name prefix to use (by default, gopassivedns) (ENV: PDNS_STATSD_PREFIX)
+   * -snaplen [int]             the snaplen used for the pcap buffer
    * -name                      the name of this sensor for use in stats and log messages (defaults to hostname) (ENV: PDNS_NAME)
    * -syslog_facility           syslog facility (ENV: PDNS_SYSLOG_FACILITY)
    * -syslog_priority           syslog priority (ENV: PDNS_SYSLOG_PRIORITY)

--- a/config.go
+++ b/config.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
-	log "github.com/Sirupsen/logrus"
 	"os"
 	"strconv"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // codebeat:disable[TOO_MANY_IVARS]
@@ -33,6 +34,8 @@ type pdnsConfig struct {
 	statsdPrefix   string
 	syslogFacility string
 	syslogPriority string
+	fluentdSocket  string
+	snapLen        int32
 }
 
 func initConfig() *pdnsConfig {
@@ -56,11 +59,13 @@ func initConfig() *pdnsConfig {
 	var pfring = flag.Bool("pfring", getEnvBool("PDNS_PFRING", false), "Capture using PF_RING")
 	var sensorName = flag.String("name", getEnvStr("PDNS_NAME", ""), "sensor name used in logging and stats reporting")
 	var statsdHost = flag.String("statsd_host", getEnvStr("PDNS_STATSD_HOST", ""), "Statsd server hostname or IP")
-	var statsdInterval = flag.Int("statsd_interval", getEnvInt("PDNS_STATSD_INTERVAL", 3), "Seconds between metric flush")   //3
+	var statsdInterval = flag.Int("statsd_interval", getEnvInt("PDNS_STATSD_INTERVAL", 5), "Seconds between metric flush")   //3
 	var statsdPrefix = flag.String("statsd_prefix", getEnvStr("PDNS_STATSD_PREFIX", "gopassivedns"), "statsd metric prefix") //gopassivedns
 	var syslogFacility = flag.String("syslog_facility", getEnvStr("PDNS_SYSLOG_FACILITY", ""), "syslog facility")            //gopassivedns
-	var syslogPriority = flag.String("syslog_priority", getEnvStr("PDNS_SYSLOG_PRIORITY", "info"), "syslog priority")        //gopassivedns
+	var syslogPriority = flag.String("syslog_priority", getEnvStr("PDNS_SYSLOG_PRIORITY", ""), "syslog priority")            //gopassivedns
 	var configFile = flag.String("config", getEnvStr("PDNS_CONFIG", ""), "config file")
+	var fluentdSocket = flag.String("fluentd_socket", getEnvStr("PDNS_FLUENTD_SOCKET", ""), "Path to Fluentd unix socket")
+	var snapLen = flag.Int("snaplen", getEnvInt("PDNS_SNAPLEN", 4096), "The snaplen used in the pcap handle")
 
 	flag.Parse()
 
@@ -105,6 +110,8 @@ func initConfig() *pdnsConfig {
 			statsdPrefix:   *statsdPrefix,
 			syslogFacility: *syslogFacility,
 			syslogPriority: *syslogPriority,
+			fluentdSocket:  *fluentdSocket,
+			snapLen:        int32(*snapLen),
 		}
 	}
 

--- a/messagepack.go
+++ b/messagepack.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"github.com/vmihailenco/msgpack"
+)
+
+// logEntry is the same as dnsLog without some fields which are not required
+// for fluentd outputs.
+type logEntry struct {
+	Query_ID             uint16 `msgpack:"query_id"`
+	Response_Code        int    `msgpack:"rcode"`
+	Question             string `msgpack:"q"`
+	Question_Type        string `msgpack:"qtype"`
+	Answer               string `msgpack:"a"`
+	Answer_Type          string `msgpack:"atype"`
+	TTL                  uint32 `msgpack:"ttl"`
+	Server               string `msgpack:"dst"`
+	Client               string `msgpack:"src"`
+	Timestamp            string `msgpack:"tstamp"`
+	Elapsed              int64  `msgpack:"elapsed"`
+	Client_Port          string `msgpack:"sport"`
+	Level                string `msgpack:"level,omitempty"` // syslog level omitted if empty
+	Length               int    `msgpack:"bytes"`
+	Proto                string `msgpack:"protocol"`
+	Truncated            bool   `msgpack:"truncated"`
+	Authoritative_Answer bool   `msgpack:"aa"`
+	Recursion_Desired    bool   `msgpack:"rd"`
+	Recursion_Available  bool   `msgpack:"ra"`
+}
+
+func (dle *dnsLogEntry) MarshalMsgpack() ([]byte, error) {
+	return msgpack.Marshal(&logEntry{
+		Query_ID:             dle.Query_ID,
+		Response_Code:        dle.Response_Code,
+		Question:             dle.Question,
+		Question_Type:        dle.Question_Type,
+		Answer:               dle.Answer,
+		Answer_Type:          dle.Answer_Type,
+		TTL:                  dle.TTL,
+		Server:               dle.Server.String(),
+		Client:               dle.Client.String(),
+		Timestamp:            dle.Timestamp,
+		Elapsed:              dle.Elapsed,
+		Client_Port:          dle.Client_Port,
+		Level:                dle.Level,
+		Length:               dle.Length,
+		Proto:                dle.Proto,
+		Truncated:            dle.Truncated,
+		Authoritative_Answer: dle.Authoritative_Answer,
+		Recursion_Desired:    dle.Recursion_Desired,
+		Recursion_Available:  dle.Recursion_Available,
+	})
+}
+
+// Yet to be finished UnmarshalMsgpack method.
+func (dle *dnsLogEntry) UnmarshalMsgpack(data []byte) error {
+	tmp := &dnsLogEntry{}
+	if err := msgpack.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/packets.go
+++ b/packets.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"errors"
-	"github.com/google/gopacket"
-	"github.com/google/gopacket/layers"
 	"net"
 	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
 )
 
 /*
@@ -139,4 +140,20 @@ func (pd *packetData) GetTimestamp() *time.Time {
 	} else {
 		return nil
 	}
+}
+
+func (pd *packetData) GetSize() *int {
+	if pd.datatype == "packet" {
+		return &pd.packet.Metadata().Length
+	} else {
+		// This needs to be improved. Currently because GetSize only works with UDP
+		// that is because we can't measure the size of the entire re-assembled stream
+		// of TCP right now. Fix pending.
+		sz := int(0)
+		return &sz
+	}
+}
+
+func (pd *packetData) GetProto() *string {
+	return &pd.datatype
 }


### PR DESCRIPTION
Hello,

This PR merges many changes that we have been running in production for over a year and felt that the community could benefit from. This fixes issues #8  and #26 however the changes are Listed in order of value

- fixes a panic in concurrent map access between the goroutines, we now have several months of stability since this change was merged. You can see the change in the use of sync package on the connTable map. This has been tested and we can successfully scale beyond 20k RPS with no panics. this also brings with it some other benefits. In that we now have consistency across goroutines so that we don't have one go routine having part of the segment and another the rest. This means we have much tighter consistency across go routines at the expense of a performance hit doing the lock/unlock (which has so far proven to be a low overhead given the improved value)
- snaplen change improves CPU utilisation drastically and is set to the max edns packet size (4k).
- adds fluentd support over a unix socket. this allows us to log off-box via the fluentd agent which uses messagepack encoding.
- updates the README to reflect the command line updates

We also add a number of fields to the logging output including
* recursion desired bool
* size of the packet (allows us to start looking for DNS tunnelling techniques)
* if the answer was authoritative (allows us to identify certain C&C behaviour)
* elapsed time between the lookup and the response (performance analysis)
* client port allows us to correlate queries from origin hosts where the host is multi-tenant (docker, vms' etc)

We also shortened the field names as used by encoding because when we do 20k rps the log volumes are insane and every byte starts to count.
